### PR TITLE
Fix responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Respotter is a reliable Responder HoneyPot!
 
+Respotter is currently undergoing a rewrite in Python
+
 ## Installation
 Download the entire repo as a Zip. Unzip the file. Right click the Respotter.ps1 file. Run as a Powershell Script. Four simple steps!
 

--- a/respotter.py
+++ b/respotter.py
@@ -35,7 +35,7 @@ class Respotter:
         sniffer = AsyncSniffer(filter="udp dst port 5355", store=True)
         sniffer.start()
         sleep(0.5)
-        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sr1(packet, timeout=self.timeout, verbose=0)
         sleep(self.timeout)
         response = sniffer.stop()
         if not response:
@@ -58,7 +58,7 @@ class Respotter:
         sniffer = AsyncSniffer(filter="udp dst port 5353", store=True)
         sniffer.start()
         sleep(0.5)
-        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sr1(packet, timeout=self.timeout, verbose=0)
         sleep(self.timeout)
         response = sniffer.stop()
         if not response:
@@ -81,7 +81,7 @@ class Respotter:
         sniffer = AsyncSniffer(filter="udp dst port 137", store=True)
         sniffer.start()
         sleep(0.5)
-        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sr1(packet, timeout=self.timeout, verbose=0)
         sleep(self.timeout)
         response = sniffer.stop()
         if not response:

--- a/respotter.py
+++ b/respotter.py
@@ -76,7 +76,7 @@ class Respotter:
                         print(f"!!! Responder detected at: {answer.rdata} (mDNS -> {self.hostname})")
         
     def send_nbns_request(self):
-        # NBNS uses the broadcast IP 255.255.255.255 and UDP port 137
+        # change IP(dst= to your local broadcast IP
         packet = IP(dst="255.255.255.255")/UDP(sport=137, dport=137)/NBNSHeader(OPCODE=0x0, NM_FLAGS=0x11, QDCOUNT=1)/NBNSQueryRequest(SUFFIX="file server service", QUESTION_NAME=self.hostname, QUESTION_TYPE="NB")
         sniffer = AsyncSniffer(filter="udp dst port 137", store=True)
         sniffer.start()

--- a/respotter.py
+++ b/respotter.py
@@ -5,7 +5,6 @@ from scapy.layers.dns import DNS, DNSQR
 from scapy.layers.inet import IP, UDP
 from scapy.layers.llmnr import LLMNRQuery, LLMNRResponse
 from scapy.layers.netbios import NBNSQueryRequest, NBNSQueryResponse, NBNSHeader
-from socket import *
 from time import sleep
 from optparse import OptionParser
 

--- a/respotter.py
+++ b/respotter.py
@@ -22,7 +22,7 @@ class Respotter:
     def __init__(self,
                  delay=30,
                  hostname="Loremipsumdolorsitamet",
-                 timeout=3,
+                 timeout=1,
                  verbosity=0):
         self.delay = delay
         self.hostname = hostname
@@ -42,9 +42,9 @@ class Respotter:
         # Print all resolved IP addresses
         for sniffed_packet in response:
             if sniffed_packet.haslayer(LLMNRResponse):
-                for i in range(sniffed_packet[LLMNRResponse].ancount):
-                    if sniffed_packet[LLMNRResponse].an[i].type == 1:  # Type 1 is A record, which contains the IP address
-                        print(f"!!! Responder detected at: {sniffed_packet[LLMNRResponse].an[i].rdata}")  # rdata field of the A record contains the IP address
+                for answer in sniffed_packet[LLMNRResponse].an:
+                    if answer.type == 1:  # Type 1 is A record, which contains the IP address
+                        print(f"!!! Responder detected at: {answer.rdata}")
         
     def send_mdns_request(self):
         # mDNS uses the multicast IP 224.0.0.251 and UDP port 5353
@@ -59,9 +59,9 @@ class Respotter:
         # Print all resolved IP addresses
         for sniffed_packet in response:
             if sniffed_packet is not None and sniffed_packet.haslayer(DNS):
-                for i in range(sniffed_packet[DNS].ancount):
-                    if sniffed_packet[DNS].an[i].type == 1:
-                        print(f"!!! Responder detected at: {sniffed_packet[DNS].an[i].rdata}")
+                for answer in sniffed_packet[DNS].an:
+                    if answer.type == 1:
+                        print(f"!!! Responder detected at: {answer.rdata}")
         
     def send_nbns_request(self):
         # NBNS uses the broadcast IP 255.255.255.255 and UDP port 137
@@ -76,8 +76,8 @@ class Respotter:
         # Print all resolved IP addresses
         for sniffed_packet in response:
             if sniffed_packet is not None and sniffed_packet.haslayer(NBNSQueryResponse):
-                for i in range(sniffed_packet[NBNSQueryResponse].RDLENGTH):
-                    print(f"!!! Responder detected at: {sniffed_packet[NBNSQueryResponse].ADDR_ENTRY[i].NB_ADDRESS}")
+                for answer in sniffed_packet[NBNSQueryResponse].ADDR_ENTRY:
+                    print(f"!!! Responder detected at: {answer.NB_ADDRESS}")
     
     def daemon(self):
         while True:

--- a/respotter.py
+++ b/respotter.py
@@ -5,8 +5,6 @@ from scapy.layers.dns import DNS, DNSQR
 from scapy.layers.inet import IP, UDP
 from scapy.layers.llmnr import LLMNRQuery, LLMNRResponse
 from scapy.layers.netbios import NBNSQueryRequest, NBNSQueryResponse, NBNSHeader
-from scapy.supersocket import SuperSocket
-from select import select
 from socket import *
 from time import sleep
 from optparse import OptionParser
@@ -34,7 +32,12 @@ class Respotter:
     def send_llmnr_request(self):
         # LLMNR uses the multicast IP 224.0.0.252 and UDP port 5355
         packet = IP(dst="224.0.0.252")/UDP(dport=5355)/LLMNRQuery(qd=DNSQR(qname=self.hostname))
-        response = sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sniffer = AsyncSniffer(filter="udp dst port 5355", store=True)
+        sniffer.start()
+        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        time.sleep(self.timeout)
+        sniffer.stop()
+        response = sniffer.results
         if response is not None and response.haslayer(LLMNRResponse):
             # Print all resolved IP addresses
             for i in range(response[LLMNRResponse].ancount):
@@ -44,7 +47,12 @@ class Respotter:
     def send_mdns_request(self):
         # mDNS uses the multicast IP 224.0.0.251 and UDP port 5353
         packet = IP(dst="224.0.0.251")/UDP(dport=5353)/DNS(rd=1, qd=DNSQR(qname=self.hostname))
-        response = sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sniffer = AsyncSniffer(filter="udp dst port 5353", store=True)
+        sniffer.start()
+        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        time.sleep(self.timeout)
+        sniffer.stop()
+        response = sniffer.results
         if response is not None and response.haslayer(DNS):
             # Print all resolved IP addresses
             for i in range(response[DNS].ancount):
@@ -54,7 +62,12 @@ class Respotter:
     def send_nbns_request(self):
         # NBNS uses the broadcast IP 255.255.255.255 and UDP port 137
         packet = IP(dst="255.255.255.255")/UDP(sport=137, dport=137)/NBNSHeader(OPCODE=0x0, NM_FLAGS=0x11, QDCOUNT=1)/NBNSQueryRequest(SUFFIX="file server service", QUESTION_NAME=self.hostname, QUESTION_TYPE="NB")
-        response = sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        sniffer = AsyncSniffer(filter="udp dst port 137", store=True)
+        sniffer.start()
+        sr1(packet, timeout=self.timeout, verbose=self.verbosity)
+        time.sleep(self.timeout)
+        sniffer.stop()
+        response = sniffer.results
         if response is not None and response.haslayer(NBNSQueryResponse):
             # Print all resolved IP addresses
             for i in range(response[NBNSQueryResponse].RDLENGTH):

--- a/respotter.py
+++ b/respotter.py
@@ -52,18 +52,9 @@ class Respotter:
                     print(f"!!! Responder detected at: {response[DNS].an[i].rdata}")
         
     def send_nbns_request(self):
-        sock = SuperSocket(AF_INET, SOCK_DGRAM)
         # NBNS uses the broadcast IP 255.255.255.255 and UDP port 137
         packet = IP(dst="255.255.255.255")/UDP(sport=137, dport=137)/NBNSHeader(OPCODE=0x0, NM_FLAGS=0x11, QDCOUNT=1)/NBNSQueryRequest(SUFFIX="file server service", QUESTION_NAME=self.hostname, QUESTION_TYPE="NB")
-        socket.send(packet)
-        sock.ins.setblocking(0)
-        ready = select([sock.ins], [], [], self.timeout)
-        if ready[0]:
-            print("got nbns response!")
-            response = sock.recv()
-        else:
-            print("nbns timeout")
-            return
+        response = sr1(packet, timeout=self.timeout, verbose=self.verbosity)
         if response is not None and response.haslayer(NBNSQueryResponse):
             # Print all resolved IP addresses
             for i in range(response[NBNSQueryResponse].RDLENGTH):

--- a/respotter.py
+++ b/respotter.py
@@ -36,13 +36,15 @@ class Respotter:
         sniffer.start()
         sr1(packet, timeout=self.timeout, verbose=self.verbosity)
         time.sleep(self.timeout)
-        sniffer.stop()
-        response = sniffer.results
-        if response is not None and response.haslayer(LLMNRResponse):
-            # Print all resolved IP addresses
-            for i in range(response[LLMNRResponse].ancount):
-                if response[LLMNRResponse].an[i].type == 1:  # Type 1 is A record, which contains the IP address
-                    print(f"!!! Responder detected at: {response[LLMNRResponse].an[i].rdata}")  # rdata field of the A record contains the IP address
+        response = sniffer.stop()
+        if not response:
+            return
+        # Print all resolved IP addresses
+        for sniffed_packet in response:
+            if sniffed_packet.haslayer(LLMNRResponse):
+                for i in range(sniffed_packet[LLMNRResponse].ancount):
+                    if sniffed_packet[LLMNRResponse].an[i].type == 1:  # Type 1 is A record, which contains the IP address
+                        print(f"!!! Responder detected at: {sniffed_packet[LLMNRResponse].an[i].rdata}")  # rdata field of the A record contains the IP address
         
     def send_mdns_request(self):
         # mDNS uses the multicast IP 224.0.0.251 and UDP port 5353
@@ -51,13 +53,15 @@ class Respotter:
         sniffer.start()
         sr1(packet, timeout=self.timeout, verbose=self.verbosity)
         time.sleep(self.timeout)
-        sniffer.stop()
-        response = sniffer.results
-        if response is not None and response.haslayer(DNS):
-            # Print all resolved IP addresses
-            for i in range(response[DNS].ancount):
-                if response[DNS].an[i].type == 1:
-                    print(f"!!! Responder detected at: {response[DNS].an[i].rdata}")
+        response = sniffer.stop()
+        if not response:
+            return
+        # Print all resolved IP addresses
+        for sniffed_packet in response:
+            if sniffed_packet is not None and sniffed_packet.haslayer(DNS):
+                for i in range(sniffed_packet[DNS].ancount):
+                    if sniffed_packet[DNS].an[i].type == 1:
+                        print(f"!!! Responder detected at: {sniffed_packet[DNS].an[i].rdata}")
         
     def send_nbns_request(self):
         # NBNS uses the broadcast IP 255.255.255.255 and UDP port 137
@@ -66,12 +70,14 @@ class Respotter:
         sniffer.start()
         sr1(packet, timeout=self.timeout, verbose=self.verbosity)
         time.sleep(self.timeout)
-        sniffer.stop()
-        response = sniffer.results
-        if response is not None and response.haslayer(NBNSQueryResponse):
-            # Print all resolved IP addresses
-            for i in range(response[NBNSQueryResponse].RDLENGTH):
-                print(f"!!! Responder detected at: {response[NBNSQueryResponse].ADDR_ENTRY[i].NB_ADDRESS}")
+        response = sniffer.stop()
+        if not response:
+            return
+        # Print all resolved IP addresses
+        for sniffed_packet in response:
+            if sniffed_packet is not None and sniffed_packet.haslayer(NBNSQueryResponse):
+                for i in range(sniffed_packet[NBNSQueryResponse].RDLENGTH):
+                    print(f"!!! Responder detected at: {sniffed_packet[NBNSQueryResponse].ADDR_ENTRY[i].NB_ADDRESS}")
     
     def daemon(self):
         while True:


### PR DESCRIPTION
There seems to be a bug in the Scapy `sr1` function with capturing the responses (https://github.com/secdev/scapy/issues/4443). As a workaround, we are manually capturing the responses with `AsyncSniffer`.