### PR TITLE
MS Teams Webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Project specific
-
+respotter.conf
 
 # Redis
 dump.rdp

--- a/messageCard.json
+++ b/messageCard.json
@@ -1,7 +1,0 @@
-{
-        "@context": "https://schema.org/extensions",
-        "@type": "MessageCard",
-        "themeColor": "0076a8",
-        "title": "Respotter Alert!",
-        "text": "ERROR"
-}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scapy @ https://github.com/secdev/scapy/archive/refs/heads/master.zip
+requests==2.26.0

--- a/teams.py
+++ b/teams.py
@@ -1,0 +1,29 @@
+import json
+import requests
+
+class TeamsException(Exception):
+    pass
+
+# You will need to edit the teams.conf file with your own webhook URL
+
+# Sending a message to Microsoft Teams:
+def send_teams_message(webhook_url, responder_ip):
+    headers = {'Content-Type': 'application/json',
+               'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0',
+               }
+    json_data = {
+        "@context": "http://schema.org/extensions",
+        "@type": "MessageCard",
+        "themeColor": "0072C6",
+        "title": "Respotter Alert!",
+        "text": "Respotter Instance found at " + responder_ip + "\n"
+    }
+    response = requests.post(webhook_url, json=json_data, headers=headers)
+    print(response.status_code)
+    if response.status_code != 200:
+        raise TeamsException(response.reason)
+ 
+if __name__ == "__main__":
+    with open("respotter.conf", "r") as config_file:
+        conf = json.load(config_file)
+    send_teams_message(conf["webhook_url"], "this is a test")


### PR DESCRIPTION
Added teams.py to send a message to a Microsoft Teams webhook using a JSON configuration file.  Additionally, added functionality to Respotter to use teams.py when running as a daemon to send a message to this webhook.