### PR TITLE
remove devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,0 @@
-FROM mcr.microsoft.com/devcontainers/python:3
-
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && \
-    apt-get -y install git
-
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --upgrade pip && \
-    pip install -r /tmp/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,0 @@
-{
-    "name": "Respotter",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": ".."
-    }
-}


### PR DESCRIPTION
I couldn't find documentation that indicated that privileged networking would be available in dev containers. To reduce the complexity of the project I'm going to just remove the devcontainer option for now.