### PR TITLE
Bug fix: new Teams webhook response code raises an error

### DIFF
--- a/utils/teams.py
+++ b/utils/teams.py
@@ -37,7 +37,7 @@ def send_teams_message(webhook_url, responder_ip):
     }
     response = requests.post(webhook_url, json=json_data, headers=headers)
     if response.status_code != 202:
-        raise TeamsException(response.reason)
+        print(f"[!] ERROR: failed to send teams webhook - {response.status_code} {response.reason}")
  
 if __name__ == "__main__":
     with open("respotter.conf", "r") as config_file:

--- a/utils/teams.py
+++ b/utils/teams.py
@@ -36,8 +36,7 @@ def send_teams_message(webhook_url, responder_ip):
         ]
     }
     response = requests.post(webhook_url, json=json_data, headers=headers)
-    print(response.status_code)
-    if response.status_code != 200:
+    if response.status_code != 202:
         raise TeamsException(response.reason)
  
 if __name__ == "__main__":


### PR DESCRIPTION
Response code changed from `200` to `202` which was causing our error handling logic to raise an exception.

Also changed the error handling to log an error instead of crashing the program.