### PR TITLE
Sniff for hosts vulnerable to Responder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project specific
 config.json
+config/
 
 # Redis
 dump.rdp

--- a/respotter.py
+++ b/respotter.py
@@ -92,7 +92,7 @@ class Respotter:
         
     def webhook_sniffer_alert(self, protocol, requester_ip, requested_hostname):
         if requester_ip in self.vulnerable_alerts:
-            if self.responder_alerts[requester_ip] > datetime.now() - timedelta(days=1):
+            if self.vulnerable_alerts[requester_ip] > datetime.now() - timedelta(days=1):
                 return
         title = f"{protocol.upper()} query detected"
         details = f"{protocol.upper()} query for '{requested_hostname}' from {requester_ip} - potentially vulnerable to Responder"

--- a/respotter.py
+++ b/respotter.py
@@ -103,7 +103,7 @@ class Respotter:
         if "discord" in self.webhooks:
             send_discord_message(self.webhooks["discord"], title=title, details=details)
             self.log.info(f"[+] Alert sent to Discord for {requester_ip}")
-        if self.vulnerable_alerts[requester_ip]:
+        if requester_ip in self.vulnerable_alerts:
             self.vulnerable_alerts[requester_ip][protocol] = datetime.now()
         else:
             self.vulnerable_alerts[requester_ip] = {protocol: datetime.now()}

--- a/respotter.py
+++ b/respotter.py
@@ -171,11 +171,6 @@ class Respotter:
         pass
             
 def parse_options():
-    # Do argv default this way, as doing it in the functional
-    # declaration sets it at compile time.
-    # if argv is None:
-    #     argv = sys.argv
-
     # add_help=False so it doesn't parse -h yet
     config_parser = argparse.ArgumentParser(add_help=False)
     config_parser.add_argument("-c", "--config", help="Specify config file", metavar="FILE")
@@ -222,7 +217,6 @@ if __name__ == "__main__":
     print("\nScanning for Responder...\n")
     
     options = parse_options()
-    
     excluded_protocols = options.exclude.split(",")
     if excluded_protocols == [""]:
         excluded_protocols = []

--- a/respotter.py
+++ b/respotter.py
@@ -92,8 +92,9 @@ class Respotter:
         
     def webhook_sniffer_alert(self, protocol, requester_ip, requested_hostname):
         if requester_ip in self.vulnerable_alerts:
-            if self.vulnerable_alerts[requester_ip] > datetime.now() - timedelta(days=1):
-                return
+            if protocol in self.vulnerable_alerts[requester_ip]:
+                if self.vulnerable_alerts[requester_ip][protocol] > datetime.now() - timedelta(days=1):
+                    return
         title = f"{protocol.upper()} query detected"
         details = f"{protocol.upper()} query for '{requested_hostname}' from {requester_ip} - potentially vulnerable to Responder"
         if "teams" in self.webhooks:
@@ -102,7 +103,10 @@ class Respotter:
         if "discord" in self.webhooks:
             send_discord_message(self.webhooks["discord"], title=title, details=details)
             self.log.info(f"[+] Alert sent to Discord for {requester_ip}")
-        self.vulnerable_alerts[requester_ip] = datetime.now()
+        if self.vulnerable_alerts[requester_ip]:
+            self.vulnerable_alerts[requester_ip][protocol] = datetime.now()
+        else:
+            self.vulnerable_alerts[requester_ip] = {protocol: datetime.now()}
             
     
     def send_llmnr_request(self):

--- a/respotter.py
+++ b/respotter.py
@@ -63,7 +63,7 @@ class Respotter:
             except:
                 self.log.error(f"[!] ERROR: could not parse subnet CIDR. Netbios protocol will be disabled.")
             self.broadcast_ip = str(network.broadcast_address)
-        else:
+        elif "nbns" not in self.excluded_protocols:
             self.log.error(f"[!] ERROR: subnet CIDR not configured. Netbios protocol will be disabled.")
             self.excluded_protocols.append("nbns")
         self.webhooks = {}

--- a/utils/discord.py
+++ b/utils/discord.py
@@ -1,9 +1,8 @@
-import json
 from discord_webhook import DiscordWebhook, DiscordEmbed
 
-def send_discord_message(webhook_url, responder_ip):
+def send_discord_message(webhook_url, title, details):
     webhook = DiscordWebhook(url=webhook_url, rate_limit_retry=True)
-    embed = DiscordEmbed(title='Responder instance found', description=f"Responder instance found at {responder_ip}", color=242424)
+    embed = DiscordEmbed(title=title, description=details, color=242424)
     embed.set_author(name='Respotter')
     embed.set_thumbnail(url='https://raw.githubusercontent.com/lawndoc/Respotter/main/assets/respotter_logo.png')
     webhook.add_embed(embed)

--- a/utils/teams.py
+++ b/utils/teams.py
@@ -22,6 +22,7 @@ def send_teams_message(webhook_url, title, details):
                         },
                         {
                             "type": "TextBlock",
+                            "wrap": True,
                             "text": details + "\n"
                         }
                     ]

--- a/utils/teams.py
+++ b/utils/teams.py
@@ -1,13 +1,7 @@
-import json
 import requests
 
-class TeamsException(Exception):
-    pass
 
-# You will need to edit the teams.conf file with your own webhook URL
-
-# Sending a message to Microsoft Teams:
-def send_teams_message(webhook_url, responder_ip):
+def send_teams_message(webhook_url, title, details):
     headers = {'Content-Type': 'application/json',
                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0',
                }
@@ -28,7 +22,7 @@ def send_teams_message(webhook_url, responder_ip):
                         },
                         {
                             "type": "TextBlock",
-                            "text": f"Responder instance found at {responder_ip}\n"
+                            "text": details + "\n"
                         }
                     ]
                 }


### PR DESCRIPTION
Forking the daemon into two sub-processes:
* Responder scanner (previous functionality)
* Multicast DNS sniffer (new code in this PR)

The sniffer will identify queries broadcast on the network from hosts that would potentially be vulnerable to Responder if an instance was running on the network.

When a query packet is found, it will log and alert all configured alert destinations.

Alerts are limited to one alert per host + protocol per day.

Closes #11 